### PR TITLE
Update active tab border color in Tsoding Emacs Gruber Darkest

### DIFF
--- a/themes/Tsoding Emacs Gruber Darkest-color-theme.json
+++ b/themes/Tsoding Emacs Gruber Darkest-color-theme.json
@@ -2009,7 +2009,7 @@
     "tab.activeForeground": "#ffffff",
     "tab.border": "#252526",
     "tab.activeBackground": "#090909",
-    "tab.activeBorder": "#090909",
+    "tab.activeBorder": "#ffdd33",
     "tab.activeBorderTop": "#00000000",
     "tab.inactiveBackground": "#0c0c0c",
     "tab.inactiveForeground": "#ffffff80",


### PR DESCRIPTION
Hello, I've been enjoying this theme, particularly the "darkest" variant. However, I sometimes find it challenging to identify the active tab, which occasionally leads to accidentally closing it. To address this, I added a simple bottom border to the active tab to make it more noticeable and user-friendly.

This is an example of how it looks : 
![image](https://github.com/user-attachments/assets/1acf081f-2859-46be-84bb-922e9f688392)

The change I've made affects only the "darkest" theme, If you end up liking it I can add it to the other variants